### PR TITLE
Load cleanup functions on database initialization

### DIFF
--- a/contrib/my_init.d/60_initdb
+++ b/contrib/my_init.d/60_initdb
@@ -37,4 +37,6 @@ if [[ "$CKAN_INIT" = "true" ]]; then
     "$CKAN_HOME/bin/paster" --plugin=ckan db init -c "${CKAN_CONFIG}/ckan.ini"
     "$CKAN_HOME/bin/paster" --plugin=ckanext-spatial spatial initdb -c "${CKAN_CONFIG}/ckan.ini"
     "$CKAN_HOME/bin/paster" --plugin=ckanext-harvest harvester initdb -c "${CKAN_CONFIG}/ckan.ini"
+    # add cleanup functions
+    "psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER ckan -q -f /scripts/ckan_cleanup_funcs.sql"
 fi


### PR DESCRIPTION
Loads cleanup function when the CKAN database is first initialized, i.e.
CKAN and harvesting tables are first set up.